### PR TITLE
[V7] Setting blob hostnames to use HTTPS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Update `~/Config/FileSystemProviders.config` replacing the default provider with
   <Provider alias="media" type="Our.Umbraco.FileSystemProviders.Azure.AzureBlobFileSystem, Our.Umbraco.FileSystemProviders.Azure">
     <Parameters>
       <add key="containerName" value="media" />
-      <add key="rootUrl" value="http://[myAccountName].blob.core.windows.net/" />
+      <add key="rootUrl" value="https://[myAccountName].blob.core.windows.net/" />
       <add key="connectionString" value="DefaultEndpointsProtocol=https;AccountName=[myAccountName];AccountKey=[myAccountKey]"/>
       <!--
         Optional configuration value determining the maximum number of days to cache items in the browser.
@@ -132,7 +132,7 @@ In `Web.config` create the new application keys and post fix each key with the `
 ```xml
 <add key="AzureBlobFileSystem.ConnectionString:media" value="DefaultEndpointsProtocol=https;AccountName=[myAccountName];AccountKey=[myAccountKey]" />
 <add key="AzureBlobFileSystem.ContainerName:media" value="media" />
-<add key="AzureBlobFileSystem.RootUrl:media" value="http://[myAccountName].blob.core.windows.net/" />
+<add key="AzureBlobFileSystem.RootUrl:media" value="https://[myAccountName].blob.core.windows.net/" />
 <add key="AzureBlobFileSystem.MaxDays:media" value="365" />
 <add key="AzureBlobFileSystem.UseDefaultRoute:media" value="true" />
 <add key="AzureBlobFileSystem.UsePrivateContainer:media" value="false" />
@@ -188,7 +188,7 @@ the cloud simply install the [configuration package](https://www.nuget.org/packa
       <settings>
         <setting key="MaxBytes" value="8194304"/>
         <setting key="Timeout" value="30000"/>
-        <setting key="Host" value="http://[myAccountName].blob.core.windows.net/media/"/>
+        <setting key="Host" value="https://[myAccountName].blob.core.windows.net/media/"/>
       </settings>
     </service>
   </services>  
@@ -208,7 +208,7 @@ If using a version of ImageProcessor.Web version [4.5.0](https://www.nuget.org/p
         <setting key="Container" value="media"/>
         <setting key="MaxBytes" value="8194304"/>
         <setting key="Timeout" value="30000"/>
-        <setting key="Host" value="http://[myAccountName].blob.core.windows.net/media"/>
+        <setting key="Host" value="https://[myAccountName].blob.core.windows.net/media"/>
       </settings>
     </service>
   </services>  

--- a/build/transforms/FileSystemProviders.config.install.xdt
+++ b/build/transforms/FileSystemProviders.config.install.xdt
@@ -10,7 +10,7 @@
   <Provider alias="media" type="Our.Umbraco.FileSystemProviders.Azure.AzureBlobFileSystem, Our.Umbraco.FileSystemProviders.Azure" xdt:Locator="Match(type)" xdt:Transform="InsertIfMissing">
     <Parameters xdt:Transform="InsertIfMissing">
       <add key="containerName" value="media" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
-      <add key="rootUrl" value="http://[myAccountName].blob.core.windows.net/" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
+      <add key="rootUrl" value="https://[myAccountName].blob.core.windows.net/" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
       <add key="connectionString" value="DefaultEndpointsProtocol=https;AccountName=[myAccountName];AccountKey=[myAccountKey]" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
       <!--
         Optional configuration value determining the maximum number of days to cache items in the browser.

--- a/build/transforms/security.config.install.xdt
+++ b/build/transforms/security.config.install.xdt
@@ -7,7 +7,7 @@
         <setting key="Container" value="media" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
         <setting key="MaxBytes" value="8194304" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
         <setting key="Timeout" value="30000" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing"/>
-        <setting key="Host" value="http://[myAccountName].blob.core.windows.net" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing"/>
+        <setting key="Host" value="https://[myAccountName].blob.core.windows.net" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing"/>
       </settings>
     </service>
   </services>

--- a/src/UmbracoFileSystemProviders.Azure.Installer/config/imageprocessor/security.config
+++ b/src/UmbracoFileSystemProviders.Azure.Installer/config/imageprocessor/security.config
@@ -8,7 +8,7 @@
         <setting key="Container" value=""/>
         <setting key="MaxBytes" value="8194304"/>
         <setting key="Timeout" value="30000"/>
-        <setting key="Host" value="http://yourhost.com/"/>
+        <setting key="Host" value="https://yourhost.com/"/>
       </settings>
     </service>-->
     <service prefix="remote.axd" name="RemoteImageService" type="ImageProcessor.Web.Services.RemoteImageService, ImageProcessor.Web">

--- a/src/UmbracoFileSystemProviders.Azure.Tests/FileSystemProviders.upgrade.config
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/FileSystemProviders.upgrade.config
@@ -5,7 +5,7 @@
   <Provider alias="media" type="Our.Umbraco.FileSystemProviders.Azure.AzureBlobFileSystem, Our.Umbraco.FileSystemProviders.Azure">
     <Parameters>
       <add key="containerName" value="media"/>
-      <add key="rootUrl" value="http://existing123456789.blob.core.windows.net/"/>
+      <add key="rootUrl" value="https://existing123456789.blob.core.windows.net/"/>
       <add key="connectionString"
   			value="DefaultEndpointsProtocol=https;AccountName=existing123456789;AccountKey=existingKey"/>
       <!--

--- a/src/UmbracoFileSystemProviders.Azure.Tests/InstallerTests.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/InstallerTests.cs
@@ -44,7 +44,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
         public void CheckUpgradeRootUrlParameter()
         {
             IEnumerable<Parameter> parameters = InstallerController.GetParametersFromXdt("..\\..\\build\\transforms\\FileSystemProviders.config.install.xdt", "FileSystemProviders.upgrade.config");
-            Assert.AreEqual("http://existing123456789.blob.core.windows.net/", parameters.Single(k => k.Key == "rootUrl").Value);
+            Assert.AreEqual("https://existing123456789.blob.core.windows.net/", parameters.Single(k => k.Key == "rootUrl").Value);
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Tests
         public void CheckNewInstallDefaultConfig()
         {
             IEnumerable<Parameter> parameters = InstallerController.GetParametersFromXdt("..\\..\\build\\transforms\\FileSystemProviders.config.install.xdt", "FileSystemProviders.default.config");
-            Assert.AreEqual("http://[myAccountName].blob.core.windows.net/", parameters.Single(k => k.Key == "rootUrl").Value);
+            Assert.AreEqual("https://[myAccountName].blob.core.windows.net/", parameters.Single(k => k.Key == "rootUrl").Value);
         }
     }
 }


### PR DESCRIPTION
Just a small niggle-y one...

Azure Blob Storage has a setting called "secure transfer required" which rejects requests that use HTTP when enabled. As documented [here](https://docs.microsoft.com/en-gb/azure/storage/common/storage-require-secure-transfer) this is enabled by default when a storage account is configured via the Azure Portal (I assume this covers 95% of use cases).

The example configuration that this package adds on install includes sample blob hostnames with placeholders for account names / keys, etc. However the sample hostnames are HTTP URLs which when used with the "default" blob storage configuration causes an API error. If you replace the whole URL it's fine, but if you're not paying attention and just swap the placeholders in the samples the service doesn't work.

I've updated the default blob hostnames to be HTTPS.