### PR TITLE
[V8] Setting blob hostnames to use HTTPS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In `Web.config` create the new application keys
 ```xml
 <add key="AzureBlobFileSystem.ConnectionString:media" value="DefaultEndpointsProtocol=https;AccountName=[myAccountName];AccountKey=[myAccountKey]" />
 <add key="AzureBlobFileSystem.ContainerName:media" value="media" />
-<add key="AzureBlobFileSystem.RootUrl:media" value="http://[myAccountName].blob.core.windows.net/" />
+<add key="AzureBlobFileSystem.RootUrl:media" value="https://[myAccountName].blob.core.windows.net/" />
 <add key="AzureBlobFileSystem.MaxDays:media" value="365" />
 <add key="AzureBlobFileSystem.UseDefaultRoute:media" value="true" />
 <add key="AzureBlobFileSystem.UsePrivateContainer:media" value="false" />
@@ -123,7 +123,7 @@ the cloud replace the `CloudImageService`setting with the following:
         <setting key="Container" value="media"/>
         <setting key="MaxBytes" value="8194304"/>
         <setting key="Timeout" value="30000"/>
-        <setting key="Host" value="http://[myAccountName].blob.core.windows.net/media"/>
+        <setting key="Host" value="https://[myAccountName].blob.core.windows.net/media"/>
       </settings>
     </service>
   </services>  

--- a/build/transforms/security.config.install.xdt
+++ b/build/transforms/security.config.install.xdt
@@ -6,8 +6,8 @@
       <settings xdt:Transform="InsertIfMissing">
         <setting key="Container" value="media" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
         <setting key="MaxBytes" value="8194304" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
-        <setting key="Timeout" value="30000" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing"/>
-        <setting key="Host" value="http://[myAccountName].blob.core.windows.net" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing"/>
+        <setting key="Timeout" value="30000" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
+        <setting key="Host" value="https://[myAccountName].blob.core.windows.net" xdt:Locator="Match(key)" xdt:Transform="InsertIfMissing" />
       </settings>
     </service>
   </services>

--- a/src/UmbracoFileSystemProviders.Azure.Installer/config/imageprocessor/security.config
+++ b/src/UmbracoFileSystemProviders.Azure.Installer/config/imageprocessor/security.config
@@ -5,10 +5,10 @@
     <!--Disable the LocalFileImageService and enable this one when using virtual paths. -->
     <!--<service name="CloudImageService" type="ImageProcessor.Web.Services.CloudImageService, ImageProcessor.Web">
       <settings>
-        <setting key="Container" value=""/>
-        <setting key="MaxBytes" value="8194304"/>
-        <setting key="Timeout" value="30000"/>
-        <setting key="Host" value="http://yourhost.com/"/>
+        <setting key="Container" value="" />
+        <setting key="MaxBytes" value="8194304" />
+        <setting key="Timeout" value="30000" />
+        <setting key="Host" value="https://yourhost.com/" />
       </settings>
     </service>-->
     <service prefix="remote.axd" name="RemoteImageService" type="ImageProcessor.Web.Services.RemoteImageService, ImageProcessor.Web">

--- a/src/UmbracoFileSystemProviders.Azure.Tests/FileSystemProviders.upgrade.config
+++ b/src/UmbracoFileSystemProviders.Azure.Tests/FileSystemProviders.upgrade.config
@@ -5,7 +5,7 @@
   <Provider alias="media" type="Our.Umbraco.FileSystemProviders.Azure.AzureBlobFileSystem, Our.Umbraco.FileSystemProviders.Azure">
     <Parameters>
       <add key="containerName" value="media"/>
-      <add key="rootUrl" value="http://existing123456789.blob.core.windows.net/"/>
+      <add key="rootUrl" value="https://existing123456789.blob.core.windows.net/"/>
       <add key="connectionString"
   			value="DefaultEndpointsProtocol=https;AccountName=existing123456789;AccountKey=existingKey"/>
       <!--


### PR DESCRIPTION
As per my pull request for V7 #145, I propose changing the sample hostnames in config to be HTTPS as it's the default configuration on Azure and therefore can be slightly confusing...

This PR updates the default blob hostnames to be HTTPS for the Umbraco 8 version of this package.