### PR TITLE
Set CanAddPhysical to false

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
@@ -159,7 +159,11 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// </summary>
         public AzureFileSystem FileSystem { get; }
 
-        public bool CanAddPhysical => throw new NotImplementedException();
+        /// <summary>
+        /// Indicates whether the filesystem can add/copy a file that is on local disk, in a fast and efficient way.
+        /// We can't so always returns false.
+        /// </summary>
+        public bool CanAddPhysical => false;
 
         /// <summary>
         /// Adds a file to the file system.


### PR DESCRIPTION
Raised in issue #151 CanAddPhysical is throwing. 

As we're not a local file system, have it always return false seems an adequate fix.