### PR TITLE
Stream blob back to client rather than read into memory.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ deploy:
      # MyGet Deployment for builds & releases
   - provider: NuGet
     server: https://www.myget.org/F/umbracofilesystemproviders-azure/api/v2/package
-    symbol_server: https://nuget.symbolsource.org/MyGet/umbracofilesystemproviders-azure
+    symbol_server: https://www.myget.org/F/umbracofilesystemproviders-azure/symbols/api/v2/package
     api_key:
       secure: fz0rUrt3B1HczUC1ZehwVsrFSWX9WZGDQoueDztLte9/+yQG+BBU7UrO+coE8lUf
     artifact: /.*\.nupkg/

--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -594,8 +594,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                     return null;
                 }
 
-                MemoryStream stream = new MemoryStream();
-                blockBlob.DownloadToStream(stream);
+                Stream stream = blockBlob.OpenRead();
 
                 if (stream.CanSeek)
                 {


### PR DESCRIPTION
Was getting out of memory exceptions on large files - shouldn't need to read the whole blob into memory before returning.