### PR TITLE
Changes GetBlockBlobReference to be public

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -780,7 +780,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// <returns>
         /// The <see cref="CloudBlockBlob"/> reference.
         /// </returns>
-        private CloudBlockBlob GetBlockBlobReference(string path)
+        public CloudBlockBlob GetBlockBlobReference(string path)
         {
             Current.Logger.Debug<AzureBlobFileSystem>($"GetBlockBlobReference(path) method executed with path:{path}");
 


### PR DESCRIPTION
Not a common scenario but it is nice to have this method public in case you want direct access to the blob storage configured for the media provider instead of having to setup up all of the connections manually based on the file system provider settings.