### PR TITLE
Added support for key vault storage

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure.Installer/InstallerController.cs
+++ b/src/UmbracoFileSystemProviders.Azure.Installer/InstallerController.cs
@@ -447,8 +447,8 @@ namespace Our.Umbraco.FileSystemProviders.Azure.Installer
 
         private static bool TestAzureCredentials(string connectionString, string containerName, BlobContainerPublicAccessType accessType)
         {
-            bool useEmulator = ConfigurationManager.AppSettings[Azure.Constants.Configuration.UseStorageEmulatorKey] != null
-                               && ConfigurationManager.AppSettings[Azure.Constants.Configuration.UseStorageEmulatorKey]
+            bool useEmulator = ConfigurationHelper.GetAppSetting(Azure.Constants.Configuration.UseStorageEmulatorKey) != null
+                               && ConfigurationHelper.GetAppSetting(Azure.Constants.Configuration.UseStorageEmulatorKey)
                                                       .Equals("true", StringComparison.InvariantCultureIgnoreCase);
             try
             {

--- a/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureBlobFileSystem.cs
@@ -113,34 +113,34 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// <param name="alias">The alias of the provider</param>
         public AzureBlobFileSystem(string alias)
         {
-            string connectionString = ConfigurationManager.AppSettings[$"{ConnectionStringKey}:{alias}"];
+            string connectionString = ConfigurationHelper.GetAppSetting(ConnectionStringKey,alias);
             if (!string.IsNullOrWhiteSpace(connectionString))
             {
-                string rootUrl = ConfigurationManager.AppSettings[$"{RootUrlKey}:{alias}"];
+                string rootUrl = ConfigurationHelper.GetAppSetting(RootUrlKey,alias);
                 if (string.IsNullOrWhiteSpace(rootUrl))
                 {
                     throw new InvalidOperationException("Azure Storage Root URL is not defined in application settings. The " + RootUrlKey + " property was not defined or is empty.");
                 }
 
-                string containerName = ConfigurationManager.AppSettings[$"{ContainerNameKey}:{alias}"];
+                string containerName = ConfigurationHelper.GetAppSetting(ContainerNameKey,alias);
                 if (string.IsNullOrWhiteSpace(containerName))
                 {
                     containerName = "media";
                 }
 
-                string maxDays = ConfigurationManager.AppSettings[$"{MaxDaysKey}:{alias}"];
+                string maxDays = ConfigurationHelper.GetAppSetting(MaxDaysKey,alias);
                 if (string.IsNullOrWhiteSpace(maxDays))
                 {
                     maxDays = "365";
                 }
 
-                string useDefaultRoute = ConfigurationManager.AppSettings[$"{UseDefaultRootKey}:{alias}"];
+                string useDefaultRoute = ConfigurationHelper.GetAppSetting(UseDefaultRootKey,alias);
                 if (string.IsNullOrWhiteSpace(useDefaultRoute))
                 {
                     useDefaultRoute = "true";
                 }
 
-                string accessType = ConfigurationManager.AppSettings[$"{UsePrivateContainerKey}:{alias}"];
+                string accessType = ConfigurationHelper.GetAppSetting(UsePrivateContainerKey,alias);
                 if (string.IsNullOrWhiteSpace(accessType))
                 {
                     accessType = "true";

--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -96,12 +96,12 @@ namespace Our.Umbraco.FileSystemProviders.Azure
                 throw new ArgumentNullException(nameof(containerName));
             }
 
-            this.DisableVirtualPathProvider = ConfigurationManager.AppSettings[DisableVirtualPathProviderKey] != null
-                                              && ConfigurationManager.AppSettings[DisableVirtualPathProviderKey]
+            this.DisableVirtualPathProvider = ConfigurationHelper.GetAppSetting(DisableVirtualPathProviderKey) != null
+                                              && ConfigurationHelper.GetAppSetting(DisableVirtualPathProviderKey)
                                              .Equals("true", StringComparison.InvariantCultureIgnoreCase);
 
-            bool useEmulator = ConfigurationManager.AppSettings[UseStorageEmulatorKey] != null
-                               && ConfigurationManager.AppSettings[UseStorageEmulatorKey]
+            bool useEmulator = ConfigurationHelper.GetAppSetting(UseStorageEmulatorKey) != null
+                               && ConfigurationHelper.GetAppSetting(UseStorageEmulatorKey)
                                                       .Equals("true", StringComparison.InvariantCultureIgnoreCase);
 
             CloudStorageAccount cloudStorageAccount;

--- a/src/UmbracoFileSystemProviders.Azure/Helpers/ConfigurationHelper.cs
+++ b/src/UmbracoFileSystemProviders.Azure/Helpers/ConfigurationHelper.cs
@@ -4,9 +4,27 @@
 
     public class ConfigurationHelper
     {
+        public static string GetAppSetting(string key)
+        {
+            var settings = ConfigurationManager.AppSettings[key];
+
+            if (!string.IsNullOrEmpty(settings))
+            {
+                return settings;
+            }
+
+            return ConfigurationManager.AppSettings[key.Replace(".", "-")];
+        }
         public static string GetAppSetting(string key, string providerAlias)
         {
-            return ConfigurationManager.AppSettings[$"{key}:{providerAlias}"];
+            var settings = ConfigurationManager.AppSettings[$"{key}:{providerAlias}"];
+
+            if (!string.IsNullOrEmpty(settings))
+            {
+                return settings;
+            }
+
+            return ConfigurationManager.AppSettings[$"{key.Replace(".", "-")}-{providerAlias}"];
         }
     }
 }


### PR DESCRIPTION
This fix is for #125 

Azure key vault storage does not support "." or ":" in the key name section in the `<appSettings>` element of the `web.config`. This PR resolves this by replacing "." or ":" in the key name with "-" as a fallback option.

This has been created after a client requested the implementation of Azure key vault falling a pen test review of the site.

Looking forward to hearing your feedback