### PR TITLE
Tls 1.2 fix

### DIFF
--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -14,6 +14,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
     using System.Globalization;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Text.RegularExpressions;
     using System.Web;
     using global::Umbraco.Core.Configuration;
@@ -88,6 +89,9 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// </exception>
         internal AzureFileSystem(string containerName, string rootUrl, string connectionString, int maxDays, bool useDefaultRoute, BlobContainerPublicAccessType accessType)
         {
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+
             if (string.IsNullOrWhiteSpace(containerName))
             {
                 throw new ArgumentNullException(nameof(containerName));

--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -14,6 +14,7 @@ namespace Our.Umbraco.FileSystemProviders.Azure
     using System.Globalization;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Text.RegularExpressions;
     using System.Web;
     using global::Umbraco.Core.Configuration;
@@ -88,6 +89,8 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// </exception>
         internal AzureFileSystem(string containerName, string rootUrl, string connectionString, int maxDays, bool useDefaultRoute, BlobContainerPublicAccessType accessType)
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+
             if (string.IsNullOrWhiteSpace(containerName))
             {
                 throw new ArgumentNullException(nameof(containerName));

--- a/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
+++ b/src/UmbracoFileSystemProviders.Azure/AzureFileSystem.cs
@@ -14,7 +14,6 @@ namespace Our.Umbraco.FileSystemProviders.Azure
     using System.Globalization;
     using System.IO;
     using System.Linq;
-    using System.Net;
     using System.Text.RegularExpressions;
     using System.Web;
     using global::Umbraco.Core.Configuration;
@@ -89,8 +88,6 @@ namespace Our.Umbraco.FileSystemProviders.Azure
         /// </exception>
         internal AzureFileSystem(string containerName, string rootUrl, string connectionString, int maxDays, bool useDefaultRoute, BlobContainerPublicAccessType accessType)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
-
             if (string.IsNullOrWhiteSpace(containerName))
             {
                 throw new ArgumentNullException(nameof(containerName));


### PR DESCRIPTION
I added SecurityProtocol declaration in the AzureFileSystem constructor so that we can use the V1 version with Blob Storage with TLS 1.2